### PR TITLE
Handle expired sessions by redirecting to home

### DIFF
--- a/Kelimedya.WebApp/Program.cs
+++ b/Kelimedya.WebApp/Program.cs
@@ -90,6 +90,9 @@ builder.Services
             OnAuthenticationFailed = ctx =>
             {
                 Console.WriteLine($"[WebApp JWT] AuthFailed: {ctx.Exception.GetType().Name} — {ctx.Exception.Message}");
+                ctx.NoResult();
+                ctx.Response.Cookies.Delete("AuthToken");
+                ctx.Response.Redirect("/");
                 return Task.CompletedTask;
             },
             OnTokenValidated = ctx =>

--- a/Kelimedya.WebApp/ViewComponents/UserDropdownViewComponent.cs
+++ b/Kelimedya.WebApp/ViewComponents/UserDropdownViewComponent.cs
@@ -19,11 +19,23 @@ public class UserDropdownViewComponent : ViewComponent
 
     public async Task<IViewComponentResult> InvokeAsync(string area)
     {
-        var client = _factory.CreateClient("DefaultApi");
         var id = _user.GetUserId();
-        var info = await client.GetFromJsonAsync<UserInfoViewModel>($"api/users/{id}")
-                   ?? new UserInfoViewModel();
-        info.Area = area;
-        return View(info);
+        if (id <= 0)
+        {
+            return View(new UserInfoViewModel { Area = area });
+        }
+
+        var client = _factory.CreateClient("DefaultApi");
+        try
+        {
+            var info = await client.GetFromJsonAsync<UserInfoViewModel>($"api/users/{id}")
+                       ?? new UserInfoViewModel();
+            info.Area = area;
+            return View(info);
+        }
+        catch (HttpRequestException)
+        {
+            return View(new UserInfoViewModel { Area = area });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Redirect users to home and clear auth cookie when JWT authentication fails, ensuring expired sessions log out cleanly
- Prevent unauthenticated requests from triggering API calls in the user dropdown component

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689de1156ee08321bb2f8d4f13fd4457