### PR TITLE
Limit game words to current lesson and add quiz feedback

### DIFF
--- a/Kelimedya.WebApi/Controllers/ProgressController.cs
+++ b/Kelimedya.WebApi/Controllers/ProgressController.cs
@@ -170,12 +170,17 @@ namespace Kelimedya.WebAPI.Controllers
         // Yeni Endpoint: Öğrencinin öğrendiği kelime kartlarını döndürür
         // GET: api/progress/wordcards/learned/{studentId}
         [HttpGet("wordcards/learned/{studentId}")]
-        public async Task<IActionResult> GetLearnedWordCards(string studentId)
+        public async Task<IActionResult> GetLearnedWordCards(string studentId, [FromQuery] int? lessonId)
         {
-            // İlgili öğrenci için IsLearned true olan StudentWordCardProgress kayıtlarını alıyoruz
-            var progresses = await _context.StudentWordCardProgresses
-                .Where(p => p.StudentId == studentId && p.IsLearned)
-                .ToListAsync();
+            var query = _context.StudentWordCardProgresses
+                .Where(p => p.StudentId == studentId && p.IsLearned);
+
+            if (lessonId.HasValue)
+            {
+                query = query.Where(p => p.LessonId == lessonId.Value);
+            }
+
+            var progresses = await query.ToListAsync();
 
             var cardIds = progresses.Select(p => p.WordCardId).ToList();
             var cards = await _context.WordCards.Where(w => cardIds.Contains(w.Id)).ToListAsync();

--- a/Kelimedya.WebApp/Areas/Student/Views/Games/CrossPuzzle.cshtml
+++ b/Kelimedya.WebApp/Areas/Student/Views/Games/CrossPuzzle.cshtml
@@ -6,6 +6,7 @@
         : "~/Areas/Student/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Çengel Bulmaca";
     var studentId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+    string lessonId = Context.Request.Query["lessonId"];
 }
 
 <!DOCTYPE html>
@@ -194,6 +195,7 @@
   <div id="gameRoot" class="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
        data-student-id="@studentId"
        data-game-id="@ViewData["GameId"]"
+       data-lesson-id="@lessonId"
        data-embed="@popUp.ToString().ToLower()">
 
     @if (!popUp)
@@ -267,7 +269,7 @@
 <script type="module">
   import { initCrossPuzzle } from '@Url.Content("~/js/games/CrossPuzzle.js")';
   const root = document.getElementById('gameRoot');
-  initCrossPuzzle(root.dataset.studentId, root.dataset.gameId);
+  initCrossPuzzle(root.dataset.studentId, root.dataset.gameId, root.dataset.lessonId);
 
     // küçük bilgi çiplerini doldur (opsiyonel)
     window.__updatePuzzleChips = function(size, acrossCount, downCount){

--- a/Kelimedya.WebApp/Areas/Student/Views/Games/SynonymMatch.cshtml
+++ b/Kelimedya.WebApp/Areas/Student/Views/Games/SynonymMatch.cshtml
@@ -3,6 +3,7 @@
     bool popUp = Context.Request.Query.ContainsKey("popUp");
     string singleWord = Context.Request.Query["word"];
     string wordId = Context.Request.Query["id"];
+    string lessonId = Context.Request.Query["lessonId"];
     Layout = popUp
         ? "~/Areas/Student/Views/Shared/_GameLayout.cshtml"
         : "~/Areas/Student/Views/Shared/_Layout.cshtml";
@@ -82,6 +83,7 @@
          data-game-id="@ViewData["GameId"]"
          data-word="@singleWord"
          data-word-id="@wordId"
+         data-lesson-id="@lessonId"
          data-embed="@popUp.ToString().ToLower()">
 
         @if (!popUp)
@@ -136,10 +138,11 @@
                 root.dataset.studentId,
                 root.dataset.gameId,
                 root.dataset.word,
-                root.dataset.wordId
+                root.dataset.wordId,
+                root.dataset.lessonId
             );
         </script>
-}
+    }
 
 </body>
 </html>

--- a/Kelimedya.WebApp/Areas/Student/Views/MyCourses/LessonDetail.cshtml
+++ b/Kelimedya.WebApp/Areas/Student/Views/MyCourses/LessonDetail.cshtml
@@ -632,7 +632,9 @@ else
             console.log('🎮 Loading game:', game.title, wordCard ? 'with word:' + wordCard.word : '');
 
             const gameFrame = document.getElementById('gameFrame');
-            const gameUrl = wordCard ? `${game.url}?popUp=1&word=${encodeURIComponent(wordCard.word)}&id=${wordCard.id}&theme=premium` : `${game.url}?popUp=1&theme=premium`;
+            const gameUrl = wordCard
+                ? `${game.url}?popUp=1&word=${encodeURIComponent(wordCard.word)}&id=${wordCard.id}&theme=premium`
+                : `${game.url}?popUp=1&lessonId=${lessonId}&theme=premium`;
             
             gameFrame.onload = function() {
                 console.log('✅ Game iframe loaded successfully');
@@ -702,7 +704,13 @@ else
         
         function answerQuiz(opt){
             const q = quizQuestions[quizIndex];
-            if(opt === q.correctOption) quizCorrect++;
+            const isCorrect = opt === q.correctOption;
+            if(isCorrect){
+                quizCorrect++;
+                showIziToastSuccess('Doğru cevap!');
+            }else{
+                showIziToastError('Yanlış cevap!');
+            }
             quizIndex++;
             setTimeout(() => {
                 showQuizQuestion();

--- a/Kelimedya.WebApp/wwwroot/js/games/CrossPuzzle.js
+++ b/Kelimedya.WebApp/wwwroot/js/games/CrossPuzzle.js
@@ -35,8 +35,8 @@ function shuffleInPlace(arr){
 }
 function pickRandom(arr){ return arr[Math.floor(Math.random() * arr.length)]; }
 
-async function loadBatch(studentId, gameId){
-    const cards = await fetchLearnedWords(studentId);
+async function loadBatch(studentId, gameId, lessonId){
+    const cards = await fetchLearnedWords(studentId, lessonId);
     if (cards.length === 0) {
         currentBatch = [];
     } else {
@@ -417,7 +417,7 @@ function addBadge(row, col, num, N, cells){
     if (!cur || num < cur) badge.textContent = num;
 }
 
-function check(studentId, gameId){
+function check(studentId, gameId, lessonId){
     let correct = true;
     document.querySelectorAll('.cp-cell:not(.blocked)').forEach(c => {
         if (c.value.toLocaleUpperCase('tr') !== c.dataset.answer) {
@@ -442,15 +442,15 @@ function check(studentId, gameId){
         if (embedded) {
             setTimeout(() => {
                 if (window.parent !== window) window.parent.postMessage('next-game', '*');
-                else refreshPuzzle(studentId, gameId);
+                else refreshPuzzle(studentId, gameId, lessonId);
             }, 1200);
         } else {
-            setTimeout(() => refreshPuzzle(studentId, gameId), 1000);
+            setTimeout(() => refreshPuzzle(studentId, gameId, lessonId), 1000);
         }
     }
 }
 
-async function reveal(studentId, gameId){
+async function reveal(studentId, gameId, lessonId){
     document.querySelectorAll('.cp-cell:not(.blocked)')
         .forEach(c => c.value = c.dataset.answer);
 
@@ -461,17 +461,17 @@ async function reveal(studentId, gameId){
     }
 }
 
-async function refreshPuzzle(studentId, gameId){
+async function refreshPuzzle(studentId, gameId, lessonId){
     offset += PAGE_SIZE;
-    await loadBatch(studentId, gameId);
+    await loadBatch(studentId, gameId, lessonId);
     placeCrosswords();
     buildGrid();
     buildClues();
     start = Date.now();
 }
 
-async function initCrossPuzzle(studentId, gameId){
-    await loadBatch(studentId, gameId);
+async function initCrossPuzzle(studentId, gameId, lessonId){
+    await loadBatch(studentId, gameId, lessonId);
     placeCrosswords();
     buildGrid();
     buildClues();
@@ -481,8 +481,8 @@ async function initCrossPuzzle(studentId, gameId){
     const revealBtn = document.getElementById('cpReveal');
     const backBtn   = document.getElementById('cpBack');
 
-    if (checkBtn)  checkBtn.onclick  = () => check(studentId, gameId);
-    if (revealBtn) revealBtn.onclick = () => reveal(studentId, gameId);
+    if (checkBtn)  checkBtn.onclick  = () => check(studentId, gameId, lessonId);
+    if (revealBtn) revealBtn.onclick = () => reveal(studentId, gameId, lessonId);
 
     const embedded = document.getElementById('gameRoot')?.dataset.embed === 'true';
     if (backBtn) {

--- a/Kelimedya.WebApp/wwwroot/js/games/SynonymMatch.js
+++ b/Kelimedya.WebApp/wwwroot/js/games/SynonymMatch.js
@@ -167,7 +167,7 @@ function refill() {
   render()
 }
 
-export async function initSynonymMatch(studentId, gameId, single, wordId) {
+export async function initSynonymMatch(studentId, gameId, single, wordId, lessonId) {
   let cards
   if (single) {
     if (wordId) {
@@ -178,7 +178,7 @@ export async function initSynonymMatch(studentId, gameId, single, wordId) {
     }
     singleMode = true
   } else {
-    cards = await fetchLearnedWords(studentId)
+    cards = await fetchLearnedWords(studentId, lessonId)
     if (cards.length === 0) {
       cards = [
         { word: "güzel", synonym: "hoş", gameQuestions: [] },

--- a/Kelimedya.WebApp/wwwroot/js/games/common.js
+++ b/Kelimedya.WebApp/wwwroot/js/games/common.js
@@ -26,8 +26,11 @@ window.iziToast = window.iziToast || {
     },
 }
 
-export async function fetchLearnedWords(studentId) {
-    const res = await fetch(`${API_BASE_URL}/api/progress/wordcards/learned/${studentId}`)
+export async function fetchLearnedWords(studentId, lessonId) {
+    const url = lessonId
+        ? `${API_BASE_URL}/api/progress/wordcards/learned/${studentId}?lessonId=${lessonId}`
+        : `${API_BASE_URL}/api/progress/wordcards/learned/${studentId}`
+    const res = await fetch(url)
     if (!res.ok) return []
     const data = await res.json()
     return data.map((x) => ({...x.wordCard, gameQuestions: x.gameQuestions}))


### PR DESCRIPTION
## Summary
- restrict Çengel Bulmaca and Eş Yakın Eşleştirme games to use words from the active lesson
- show success or error toast when answering end-of-lesson quiz questions

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689de93acbc88321b1b009e83533e42e